### PR TITLE
update in line with Chapel 1.27

### DIFF
--- a/apps/blackscholes/bs.baseline.chpl
+++ b/apps/blackscholes/bs.baseline.chpl
@@ -113,7 +113,7 @@ proc main() {
       var X = d1;
       var absX = abs(X);
       var t = one / (one + temp4 * absX);
-      var y = one - oneBySqrt2pi * Math.exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
+      var y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
 		phiD1 = one - y;
       } else {
@@ -121,7 +121,7 @@ proc main() {
       }
       // phiD2 = phi(d2)
       X = d2;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
@@ -134,7 +134,7 @@ proc main() {
 
       // phiD1 = phi(-d1);
       X = -d1;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
@@ -145,7 +145,7 @@ proc main() {
 
       // phiD2 = phi(-d2);
       X = -d2;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {

--- a/apps/blackscholes/bs.hybrid.chpl
+++ b/apps/blackscholes/bs.hybrid.chpl
@@ -134,7 +134,7 @@ proc main() {
       var X = d1;
       var absX = abs(X);
       var t = one / (one + temp4 * absX);
-      var y = one - oneBySqrt2pi * Math.exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
+      var y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
 		phiD1 = one - y;
       } else {
@@ -142,7 +142,7 @@ proc main() {
       }
       // phiD2 = phi(d2)
       X = d2;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
@@ -155,7 +155,7 @@ proc main() {
 
       // phiD1 = phi(-d1);
       X = -d1;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
@@ -166,7 +166,7 @@ proc main() {
 
       // phiD2 = phi(-d2);
       X = -d2;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {

--- a/apps/blackscholes/bs.hybrid.dist.chpl
+++ b/apps/blackscholes/bs.hybrid.dist.chpl
@@ -140,7 +140,7 @@ proc main() {
       var X = d1;
       var absX = abs(X);
       var t = one / (one + temp4 * absX);
-      var y = one - oneBySqrt2pi * Math.exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
+      var y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
 		phiD1 = one - y;
       } else {
@@ -148,7 +148,7 @@ proc main() {
       }
       // phiD2 = phi(d2)
       X = d2;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
@@ -161,7 +161,7 @@ proc main() {
 
       // phiD1 = phi(-d1);
       X = -d1;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
@@ -172,7 +172,7 @@ proc main() {
 
       // phiD2 = phi(-d2);
       X = -d2;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {

--- a/apps/blackscholes/bs.hybrid.dist.mid.chpl
+++ b/apps/blackscholes/bs.hybrid.dist.mid.chpl
@@ -6,8 +6,7 @@ use Time;
 use GPUIterator;
 use GPUAPI;
 use BlockDist;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Runtime Options
@@ -32,7 +31,7 @@ var call: [D] real(32);
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchBS(drand: c_void_ptr, dput: c_void_ptr, dcall: c_void_ptr, N: size_t);
+extern proc LaunchBS(drand: c_void_ptr, dput: c_void_ptr, dcall: c_void_ptr, N: c_size_t);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)
@@ -48,7 +47,7 @@ proc CUDAWrapper(lo: int, hi: int, N: int) {
   var dput = new GPUArray(lput);
   var dcall = new GPUArray(lcall);
   toDevice(drand);
-  LaunchBS(drand.dPtr(), dput.dPtr(), dcall.dPtr(), N:size_t);
+  LaunchBS(drand.dPtr(), dput.dPtr(), dcall.dPtr(), N:c_size_t);
   DeviceSynchronize();
   fromDevice(dput, dcall);
   if (verbose) { ProfilerStop(); }
@@ -151,7 +150,7 @@ proc main() {
       var X = d1;
       var absX = abs(X);
       var t = one / (one + temp4 * absX);
-      var y = one - oneBySqrt2pi * Math.exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
+      var y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
 		phiD1 = one - y;
       } else {
@@ -159,7 +158,7 @@ proc main() {
       }
       // phiD2 = phi(d2)
       X = d2;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
@@ -172,7 +171,7 @@ proc main() {
 
       // phiD1 = phi(-d1);
       X = -d1;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
@@ -183,7 +182,7 @@ proc main() {
 
       // phiD2 = phi(-d2);
       X = -d2;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {

--- a/apps/blackscholes/bs.hybrid.dist.midlow.chpl
+++ b/apps/blackscholes/bs.hybrid.dist.midlow.chpl
@@ -6,8 +6,7 @@ use Time;
 use GPUIterator;
 use GPUAPI;
 use BlockDist;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Runtime Options
@@ -32,7 +31,7 @@ var call: [D] real(32);
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchBS(drand: c_void_ptr, dput: c_void_ptr, dcall: c_void_ptr, N: size_t);
+extern proc LaunchBS(drand: c_void_ptr, dput: c_void_ptr, dcall: c_void_ptr, N: c_size_t);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)
@@ -45,12 +44,12 @@ proc CUDAWrapper(lo: int, hi: int, N: int) {
   ref lcall = call.localSlice(lo .. hi);
   if (verbose) { ProfilerStart(); }
   var drand, dput, dcall: c_void_ptr;
-  var size: size_t = (lrand.size:size_t * c_sizeof(lrand.eltType));
+  var size: c_size_t = (lrand.size:c_size_t * c_sizeof(lrand.eltType));
   Malloc(drand, size);
   Malloc(dput, size);
   Malloc(dcall, size);
   Memcpy(drand, c_ptrTo(lrand), size, 0);
-  LaunchBS(drand, dput, dcall, N:size_t);
+  LaunchBS(drand, dput, dcall, N:c_size_t);
   DeviceSynchronize();
   Memcpy(c_ptrTo(lput), dput, size, 1);
   Memcpy(c_ptrTo(lcall), dcall, size, 1);
@@ -157,7 +156,7 @@ proc main() {
       var X = d1;
       var absX = abs(X);
       var t = one / (one + temp4 * absX);
-      var y = one - oneBySqrt2pi * Math.exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
+      var y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
 		phiD1 = one - y;
       } else {
@@ -165,7 +164,7 @@ proc main() {
       }
       // phiD2 = phi(d2)
       X = d2;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
@@ -178,7 +177,7 @@ proc main() {
 
       // phiD1 = phi(-d1);
       X = -d1;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {
@@ -189,7 +188,7 @@ proc main() {
 
       // phiD2 = phi(-d2);
       X = -d2;
-      absX = Math.abs(X);
+      absX = abs(X);
       t = one / (one + temp4 * absX);
       y = one - oneBySqrt2pi * exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))));
       if (X  < zero) {

--- a/apps/logisticregression/lr.hybrid.dist.mid.chpl
+++ b/apps/logisticregression/lr.hybrid.dist.mid.chpl
@@ -6,8 +6,7 @@ use ReplicatedDist;
 use GPUIterator;
 use GPUAPI;
 use BlockDist;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Runtime Options

--- a/apps/logisticregression/lr.hybrid.dist.midlow.chpl
+++ b/apps/logisticregression/lr.hybrid.dist.midlow.chpl
@@ -6,8 +6,7 @@ use ReplicatedDist;
 use GPUIterator;
 use GPUAPI;
 use BlockDist;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Runtime Options
@@ -57,16 +56,16 @@ proc CUDAWrapper(lo: int, hi: int, N: int) {
   ref lW = W.localSlice(lo .. hi);
   if (verbose) { ProfilerStart(); }
   var dX, dY, dWcurr, dW: c_void_ptr;
-  Malloc(dX, X.size:size_t * c_sizeof(X.eltType));
-  Malloc(dY, Y.size:size_t * c_sizeof(Y.eltType));
-  Malloc(dWcurr, Wcurr.size:size_t * c_sizeof(Wcurr.eltType));
-  Malloc(dW, lW.size:size_t * c_sizeof(lW.eltType));
-  Memcpy(dX, c_ptrTo(X.replicand(here)), X.size:size_t * c_sizeof(X.eltType), 0);
-  Memcpy(dY, c_ptrTo(Y.replicand(here)), Y.size:size_t * c_sizeof(Y.eltType), 0);
-  Memcpy(dWcurr, c_ptrTo(Wcurr.replicand(here)), Wcurr.size:size_t * c_sizeof(Wcurr.eltType), 0);
+  Malloc(dX, X.size:c_size_t * c_sizeof(X.eltType));
+  Malloc(dY, Y.size:c_size_t * c_sizeof(Y.eltType));
+  Malloc(dWcurr, Wcurr.size:c_size_t * c_sizeof(Wcurr.eltType));
+  Malloc(dW, lW.size:c_size_t * c_sizeof(lW.eltType));
+  Memcpy(dX, c_ptrTo(X.replicand(here)), X.size:c_size_t * c_sizeof(X.eltType), 0);
+  Memcpy(dY, c_ptrTo(Y.replicand(here)), Y.size:c_size_t * c_sizeof(Y.eltType), 0);
+  Memcpy(dWcurr, c_ptrTo(Wcurr.replicand(here)), Wcurr.size:c_size_t * c_sizeof(Wcurr.eltType), 0);
   LaunchLR(dX, dY, dW, dWcurr, alpha, nSamples, nFeatures, lo, hi, N);
   DeviceSynchronize();
-  Memcpy(c_ptrTo(lW), dW, lW.size:size_t * c_sizeof(lW.eltType), 1);
+  Memcpy(c_ptrTo(lW), dW, lW.size:c_size_t * c_sizeof(lW.eltType), 1);
   Free(dX);
   Free(dY);
   Free(dW);

--- a/apps/mm/mm.hybrid.dist.mid.chpl
+++ b/apps/mm/mm.hybrid.dist.mid.chpl
@@ -6,8 +6,7 @@ use ReplicatedDist;
 use GPUIterator;
 use GPUAPI;
 use BlockDist;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Runtime Options

--- a/apps/mm/mm.hybrid.dist.midlow.chpl
+++ b/apps/mm/mm.hybrid.dist.midlow.chpl
@@ -6,8 +6,7 @@ use ReplicatedDist;
 use GPUIterator;
 use GPUAPI;
 use BlockDist;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Runtime Options
@@ -56,16 +55,16 @@ proc CUDAWrapper(lo: int, hi: int, N: int) {
   var dA, dB, dC: c_void_ptr;
 
   //writeln("lA.size: ", lA.size, " B.size: ", B.size);
-  Malloc(dA, lA.size:size_t * c_sizeof(lA.eltType));
-  Malloc(dB, B.size:size_t  * c_sizeof(B.eltType));
-  Malloc(dC, lC.size:size_t * c_sizeof(lC.eltType));
+  Malloc(dA, lA.size:c_size_t * c_sizeof(lA.eltType));
+  Malloc(dB, B.size:c_size_t  * c_sizeof(B.eltType));
+  Malloc(dC, lC.size:c_size_t * c_sizeof(lC.eltType));
 
-  Memcpy(dA, c_ptrTo(lA), lA.size:size_t * c_sizeof(lA.eltType), 0);
-  Memcpy(dB, c_ptrTo(B.replicand(here)),  B.size:size_t  * c_sizeof(B.eltType),  0);
+  Memcpy(dA, c_ptrTo(lA), lA.size:c_size_t * c_sizeof(lA.eltType), 0);
+  Memcpy(dB, c_ptrTo(B.replicand(here)),  B.size:c_size_t  * c_sizeof(B.eltType),  0);
 
   LaunchMM(dA, dB, dC, n*n, 0, hi-lo, N, tiled);
   DeviceSynchronize();
-  Memcpy(c_ptrTo(lC), dC, lC.size:size_t * c_sizeof(lC.eltType), 1);
+  Memcpy(c_ptrTo(lC), dC, lC.size:c_size_t * c_sizeof(lC.eltType), 1);
 
   Free(dA);
   Free(dB);

--- a/apps/stream/stream.hybrid.dist.mid.chpl
+++ b/apps/stream/stream.hybrid.dist.mid.chpl
@@ -7,8 +7,7 @@ use GPUIterator;
 use GPUAPI;
 use BlockDist;
 use SysBasic;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Runtime Options
@@ -34,7 +33,7 @@ var C: [D] real(32);
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchStream(A: c_void_ptr, B: c_void_ptr, C: c_void_ptr, alpha: c_float, N: size_t);
+extern proc LaunchStream(A: c_void_ptr, B: c_void_ptr, C: c_void_ptr, alpha: c_float, N: c_size_t);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)
@@ -56,7 +55,7 @@ proc CUDAWrapper(lo: int, hi: int, N: int) {
   var dC = new GPUArray(lC);
 
   toDevice(dB, dC);
-  LaunchStream(dA.dPtr(), dB.dPtr(), dC.dPtr(), alpha, N: size_t);
+  LaunchStream(dA.dPtr(), dB.dPtr(), dC.dPtr(), alpha, N: c_size_t);
   DeviceSynchronize();
   dA.fromDevice();
 

--- a/apps/stream/stream.hybrid.dist.midlow.chpl
+++ b/apps/stream/stream.hybrid.dist.midlow.chpl
@@ -7,8 +7,7 @@ use GPUIterator;
 use GPUAPI;
 use BlockDist;
 use SysBasic;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Runtime Options
@@ -34,7 +33,7 @@ var C: [D] real(32);
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchStream(A: c_void_ptr, B: c_void_ptr, C: c_void_ptr, alpha: c_float, N: size_t);
+extern proc LaunchStream(A: c_void_ptr, B: c_void_ptr, C: c_void_ptr, alpha: c_float, N: c_size_t);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)
@@ -52,14 +51,14 @@ proc CUDAWrapper(lo: int, hi: int, N: int) {
   //writeln("localSlice Size:", lA.size);
   if (verbose) { ProfilerStart(); }
   var dA, dB, dC: c_void_ptr;
-  var size: size_t = (lA.size:size_t * c_sizeof(lA.eltType));
+  var size: c_size_t = (lA.size:c_size_t * c_sizeof(lA.eltType));
   Malloc(dA, size);
   Malloc(dB, size);
   Malloc(dC, size);
 
   Memcpy(dB, c_ptrTo(lB), size, 0);
   Memcpy(dC, c_ptrTo(lC), size, 0);
-  LaunchStream(dA, dB, dC, alpha, N: size_t);
+  LaunchStream(dA, dB, dC, alpha, N: c_size_t);
   DeviceSynchronize();
   Memcpy(c_ptrTo(lA), dA, size, 1);
 

--- a/apps/vector_copy/vc.hybrid.dist.mid.chpl
+++ b/apps/vector_copy/vc.hybrid.dist.mid.chpl
@@ -6,8 +6,7 @@ use Time;
 use GPUIterator;
 use GPUAPI;
 use BlockDist;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Runtime Options
@@ -31,7 +30,7 @@ var B: [D] real(32);
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchVC(A: c_void_ptr, B: c_void_ptr, N: size_t);
+extern proc LaunchVC(A: c_void_ptr, B: c_void_ptr, N: c_size_t);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)
@@ -48,7 +47,7 @@ proc CUDAWrapper(lo: int, hi: int, N: int) {
   var dA = new GPUArray(lA);
   var dB = new GPUArray(lB);
   dB.toDevice();
-  LaunchVC(dA.dPtr(), dB.dPtr(), N: size_t);
+  LaunchVC(dA.dPtr(), dB.dPtr(), N: c_size_t);
   DeviceSynchronize();
   dA.fromDevice();
   if (verbose) { ProfilerStop(); }

--- a/apps/vector_copy/vc.hybrid.dist.midlow.chpl
+++ b/apps/vector_copy/vc.hybrid.dist.midlow.chpl
@@ -6,8 +6,7 @@ use Time;
 use GPUIterator;
 use GPUAPI;
 use BlockDist;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Runtime Options
@@ -31,7 +30,7 @@ var B: [D] real(32);
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchVC(A: c_void_ptr, B: c_void_ptr, N: size_t);
+extern proc LaunchVC(A: c_void_ptr, B: c_void_ptr, N: c_size_t);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)
@@ -46,11 +45,11 @@ proc CUDAWrapper(lo: int, hi: int, N: int) {
   ref lB = B.localSlice(lo .. hi);
   if (verbose) { ProfilerStart(); }
   var dA, dB: c_void_ptr;
-  var size: size_t = (lA.size:size_t * c_sizeof(lA.eltType));
+  var size: c_size_t = (lA.size:c_size_t * c_sizeof(lA.eltType));
   Malloc(dA, size);
   Malloc(dB, size);
   Memcpy(dB, c_ptrTo(lB), size, 0);
-  LaunchVC(dA, dB, N: size_t);
+  LaunchVC(dA, dB, N: c_size_t);
   DeviceSynchronize();
   Memcpy(c_ptrTo(lA), dA, size, 1);
   Free(dA);

--- a/cmake/BuildGPUCode.cmake
+++ b/cmake/BuildGPUCode.cmake
@@ -1,4 +1,5 @@
 # FindCUDA
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler")
 include(CheckLanguage)
 check_language(CUDA QUIET)
 

--- a/doc/rst/api/gpuapi.rst
+++ b/doc/rst/api/gpuapi.rst
@@ -11,7 +11,7 @@ MID-level API Reference
 
    .. method:: proc init(ref arr, pitched=false)
 
-      Allocates memory on the device. The allocation size is automatically computed by this module -i.e., ``(arr.size: size_t) * c_sizeof(arr.eltType)``, which means the index space is linearlized when ``arr`` is multi-dimensional. Also, if ``arr`` is 2D and ``pitched=true``, pitched allocation is performed and the host and device pitch can be obtained by doing ``obj.hpitch`` and ``obj.dpitch``. Note that the allocated memory is automatically reclaimed when the object is deleted.
+      Allocates memory on the device. The allocation size is automatically computed by this module -i.e., ``(arr.size: c_size_t) * c_sizeof(arr.eltType)``, which means the index space is linearlized when ``arr`` is multi-dimensional. Also, if ``arr`` is 2D and ``pitched=true``, pitched allocation is performed and the host and device pitch can be obtained by doing ``obj.hpitch`` and ``obj.dpitch``. Note that the allocated memory is automatically reclaimed when the object is deleted.
 
       :arg arr: The reference of the non-distributed Chapel Array that will be mapped onto the device.
       :arg pitched: whether pitched allocation is performed or not (default is false)
@@ -136,7 +136,7 @@ MID-level API Reference
 MID-LOW-level API Reference
 ############################
 
-.. method:: Malloc(ref devPtr: c_void_ptr, size: size_t)
+.. method:: Malloc(ref devPtr: c_void_ptr, size: c_size_t)
 
    Allocates memory on the device.
 
@@ -144,7 +144,7 @@ MID-LOW-level API Reference
    :type devPtr: `c_voidPtr`
 
    :arg size: Allocation size in bytes
-   :type size: `size_t`
+   :type size: `c_size_t`
 
    .. code-block:: chapel
       :emphasize-lines: 6,21
@@ -154,7 +154,7 @@ MID-LOW-level API Reference
 
       proc GPUCallBack(lo: int, hi: int, N: int) {
         var dA: c_void_ptr;
-        Malloc(dA, (A.size: size_t) * c_sizeof(A.eltType));
+        Malloc(dA, (A.size: c_size_t) * c_sizeof(A.eltType));
         ...
       }
 
@@ -169,7 +169,7 @@ MID-LOW-level API Reference
         var dA: c_void_ptr;
         // get the local portion of the distributed array
         var localA = A.localSlice(lo...hi);
-        Malloc(dA, (localA.size: size_t) * c_sizeof(localA.eltType));
+        Malloc(dA, (localA.size: c_size_t) * c_sizeof(localA.eltType));
         ...
       }
 
@@ -180,7 +180,7 @@ MID-LOW-level API Reference
 
 
 
-.. method:: MallocPitch(ref devPtr: c_void_ptr, ref pitch: size_t, width: size_t, height: size_t)
+.. method:: MallocPitch(ref devPtr: c_void_ptr, ref pitch: c_size_t, width: c_size_t, height: c_size_t)
 
    Allocates pitched 2D memory on the device.
 
@@ -188,17 +188,17 @@ MID-LOW-level API Reference
    :type devPtr: `c_voidPtr`
 
    :arg pitch: Pitch for allocation on the device, which is set by the runtime
-   :type pitch: `size_t`
+   :type pitch: `c_size_t`
 
    :arg width: The width of the original Chapel array (in bytes)
-   :type width: `size_t`
+   :type width: `c_size_t`
 
    :arg height: The number of rows (height)
-   :type height: `size_t`
+   :type height: `c_size_t`
 
    .. note:: A working example can be found `here <https://github.com/ahayashi/chapel-gpu/blob/master/example/gpuapi/pitched2d/pitched2d.chpl>`_. The detailed descirption of the underlying CUDA API can be found `here <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html#group__CUDART__MEMORY_1g32bd7a39135594788a542ae72217775c>`_.
 
-.. method:: Memcpy(dst: c_void_ptr, src: c_void_ptr, count: size_t, kind: int)
+.. method:: Memcpy(dst: c_void_ptr, src: c_void_ptr, count: c_size_t, kind: int)
 
    Transfers data between the host and the device
 
@@ -209,7 +209,7 @@ MID-LOW-level API Reference
    :type src: `c_void_ptr`
 
    :arg count: size in bytes to be transferred
-   :type count: `size_t`
+   :type count: `c_size_t`
 
    :arg kind: type of transfer (``0``: host-to-device, ``1``: device-to-host)
    :type kind: `int`
@@ -222,7 +222,7 @@ MID-LOW-level API Reference
 
       proc GPUCallBack(lo: int, hi: int, N: int) {
         var dA: c_void_ptr;
-        Malloc(dA, (A.size: size_t) * c_sizeof(A.eltType));
+        Malloc(dA, (A.size: c_size_t) * c_sizeof(A.eltType));
         // host-to-device
         Memcpy(dA, c_ptrTo(A), size, 0);
         // device-to-host
@@ -231,7 +231,7 @@ MID-LOW-level API Reference
 
    .. note:: ``c_ptrTo(A)`` returns a pointer to the Chapel rectangular array ``A``. For more details, see `this document <https://chapel-lang.org/docs/builtins/CPtr.html#CPtr.c_ptrTo>`_.
 
-.. method:: Memcpy2D(dst: c_void_ptr, dpitch: size_t, src: c_void_ptr, spitch: size_t, width: size_t, height:size_t, kind: int)
+.. method:: Memcpy2D(dst: c_void_ptr, dpitch: c_size_t, src: c_void_ptr, spitch: c_size_t, width: c_size_t, height:c_size_t, kind: int)
 
    Transfers pitched 2D array between the host and the device
 
@@ -239,19 +239,19 @@ MID-LOW-level API Reference
    :type dst: `c_void_ptr`
 
    :arg dpitch: the pitch of destination memory
-   :type dpitch: `size_t`
+   :type dpitch: `c_size_t`
 
    :arg src: the source address
    :type src: `c_void_ptr`
 
    :arg spitch: the pitch of source memory
-   :type spitch: `size_t`
+   :type spitch: `c_size_t`
 
    :arg width: the width of 2D array to be transferred (in bytes)
-   :type width: `size_t`
+   :type width: `c_size_t`
 
    :arg height: the height of 2D array to be transferred (# of rows)
-   :type height: `size_t`
+   :type height: `c_size_t`
 
    :arg kind: type of transfer (``0``: host-to-device, ``1``: device-to-host)
    :type kind: `int`

--- a/doc/rst/instructions/mid-low.rst
+++ b/doc/rst/instructions/mid-low.rst
@@ -41,11 +41,11 @@ At the MID-LOW-level, most of the CUDA/HIP/OpenCL-level 1) device memory allocat
 
    proc GPUCallBack(lo: int, hi: int, N: int) {
      var dA, dB: c_void_ptr;
-     var size: size_t = (lA.size:size_t * c_sizeof(lA.eltType));
+     var size: c_size_t = (lA.size:c_size_t * c_sizeof(lA.eltType));
      Malloc(dA, size);
      Malloc(dB, size);
      Memcpy(dB, c_ptrTo(lB), size, 0);
-     LaunchVC(dA, dB, N: size_t);
+     LaunchVC(dA, dB, N: c_size_t);
      DeviceSynchronize();
      Memcpy(c_ptrTo(lA), dA, size, 1);
      Free(dA);

--- a/doc/rst/instructions/mid.rst
+++ b/doc/rst/instructions/mid.rst
@@ -45,7 +45,7 @@ At the MID-level, most of the CUDA/HIP/OpenCL-level 1) device memory allocation,
      var dA = new GPUArray(A);
      var dB = new GPUArray(B);
      dB.toDevice();
-     LaunchVC(dA.dPtr(), dB.dPtr(), N: size_t);
+     LaunchVC(dA.dPtr(), dB.dPtr(), N: c_size_t);
      dA.fromDevice();
      free(dA, dB);
    }

--- a/example/gpuapi/1d/1d.chpl
+++ b/example/gpuapi/1d/1d.chpl
@@ -1,6 +1,5 @@
 use GPUAPI;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
 extern proc kernel(dA: c_void_ptr, n: int);
 
@@ -21,7 +20,7 @@ proc init() {
 init();
 
 var dA: c_void_ptr;
-var size: size_t = A.size:size_t * c_sizeof(A.eltType);
+var size: c_size_t = A.size:c_size_t * c_sizeof(A.eltType);
 Malloc(dA, size);
 Memcpy(dA, c_ptrTo(A), size, 0);
 kernel(dA, D.dim(0).size);

--- a/example/gpuapi/2d/2d.chpl
+++ b/example/gpuapi/2d/2d.chpl
@@ -1,6 +1,5 @@
 use GPUAPI;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
 extern proc kernel(dA: c_void_ptr, nRows: int, nCols: int);
 
@@ -21,7 +20,7 @@ proc init() {
 init();
 
 var dA: c_void_ptr;
-var size: size_t = A.size:size_t * c_sizeof(A.eltType);
+var size: c_size_t = A.size:c_size_t * c_sizeof(A.eltType);
 Malloc(dA, size);
 Memcpy(dA, c_ptrTo(A), size, 0);
 kernel(dA, D.dim(0).size, D.dim(1).size);

--- a/example/gpuapi/async/async.chpl
+++ b/example/gpuapi/async/async.chpl
@@ -1,6 +1,5 @@
 use GPUAPI;
-use SysCTypes;
-use CPtr;
+use CTypes;
 use Futures;
 
 extern proc kernel(dA: c_void_ptr);

--- a/example/gpuapi/jagged/jagged.chpl
+++ b/example/gpuapi/jagged/jagged.chpl
@@ -1,7 +1,7 @@
 use GPUAPI;
-use SysCTypes;
+use CTypes;
 
-extern proc kernelLOW(a: [] c_ptr(int), b: [] size_t, n: int);
+extern proc kernelLOW(a: [] c_ptr(int), b: [] c_size_t, n: int);
 extern proc kernelMIDLOW(a: c_ptr(c_void_ptr), n: int);
 
 class C {
@@ -46,7 +46,7 @@ writeln("[LOW]");
 {
     init();
     ref ptrs = [c_ptrTo(Cs[0].x), c_ptrTo(Cs[1].x)];
-    ref sizes = [Cs[0].x.size:size_t*c_sizeof(int), Cs[1].x.size:size_t*c_sizeof(int)];
+    ref sizes = [Cs[0].x.size:c_size_t*c_sizeof(int), Cs[1].x.size:c_size_t*c_sizeof(int)];
     kernelLOW(ptrs, sizes, N);
     verify("LOW");
 }
@@ -58,18 +58,18 @@ writeln("[MIDLOW]");
   var dA: [0..#N] c_void_ptr;
   var dAs: c_ptr(c_void_ptr);
   for i in 0..#N {
-    const size = Cs[i].x.size:size_t*c_sizeof(int);
+    const size = Cs[i].x.size:c_size_t*c_sizeof(int);
     Malloc(dA[i], size);
     Memcpy(dA[i], c_ptrTo(Cs[i].x), size, 0);
   }
-  const size = N: size_t * c_sizeof(c_ptr(c_void_ptr));
+  const size = N: c_size_t * c_sizeof(c_ptr(c_void_ptr));
   Malloc(dAs, size);
   Memcpy(dAs, c_ptrTo(dA), size, 0);
 
   kernelMIDLOW(dAs, N);
   DeviceSynchronize();
   for i in 0..#N {
-    const size = Cs[i].x.size:size_t*c_sizeof(int);
+    const size = Cs[i].x.size:c_size_t*c_sizeof(int);
     Memcpy(c_ptrTo(Cs[i].x), dA[i], size, 1);
   }
   // Verification

--- a/example/gpuapi/pitched2d/pitched2d.chpl
+++ b/example/gpuapi/pitched2d/pitched2d.chpl
@@ -1,8 +1,7 @@
 use GPUAPI;
-use SysCTypes;
-use CPtr;
+use CTypes;
 
-extern proc kernel(dA: c_void_ptr, nRows: size_t, nCols: size_t, dpitch: size_t);
+extern proc kernel(dA: c_void_ptr, nRows: c_size_t, nCols: c_size_t, dpitch: c_size_t);
 
 var D = {0..8, 0..8};
 var A: [D] int;
@@ -20,17 +19,17 @@ proc init() {
 init();
 
 var dA: c_void_ptr;
-var hpitch: size_t = D.dim(1).size:size_t * c_sizeof(A.eltType);
-var dpitch: size_t;
+var hpitch: c_size_t = D.dim(1).size:c_size_t * c_sizeof(A.eltType);
+var dpitch: c_size_t;
 
-MallocPitch(dA, dpitch, hpitch, D.dim(0).size: size_t);
+MallocPitch(dA, dpitch, hpitch, D.dim(0).size: c_size_t);
 writeln("MID-LOW: pitch on the host:", hpitch);
 writeln("MID-LOW: pitch on the device: ", dpitch);
 
-Memcpy2D(dA, dpitch, c_ptrTo(A), hpitch, hpitch, D.dim(0).size: size_t, 0);
-kernel(dA, D.dim(0).size: size_t, D.dim(1).size: size_t, dpitch);
+Memcpy2D(dA, dpitch, c_ptrTo(A), hpitch, hpitch, D.dim(0).size: c_size_t, 0);
+kernel(dA, D.dim(0).size: c_size_t, D.dim(1).size: c_size_t, dpitch);
 DeviceSynchronize();
-Memcpy2D(c_ptrTo(A), hpitch, dA, dpitch, hpitch, D.dim(0).size: size_t, 1);
+Memcpy2D(c_ptrTo(A), hpitch, dA, dpitch, hpitch, D.dim(0).size: c_size_t, 1);
 
 // Verify
 if (A.equals(V)) {
@@ -50,7 +49,7 @@ if (dA2.hpitch != dA2.dpitch) {
 }
 
 dA2.toDevice();
-kernel(dA2.dPtr(), D.dim(0).size: size_t, D.dim(1).size: size_t, dA2.dpitch);
+kernel(dA2.dPtr(), D.dim(0).size: c_size_t, D.dim(1).size: c_size_t, dA2.dpitch);
 DeviceSynchronize();
 dA2.fromDevice();
 
@@ -67,7 +66,7 @@ var dA3 = new GPUArray(A, true);
 writeln("MID (pitch=true) pitch on the host:", dA3.hpitch);
 writeln("MID (pitch=true) pitch on the device: ", dA3.dpitch);
 dA3.toDevice();
-kernel(dA3.dPtr(), D.dim(0).size: size_t, D.dim(1).size: size_t, dA3.dpitch);
+kernel(dA3.dPtr(), D.dim(0).size: c_size_t, D.dim(1).size: c_size_t, dA3.dpitch);
 DeviceSynchronize();
 dA3.fromDevice();
 

--- a/src/GPUIterator.chpl
+++ b/src/GPUIterator.chpl
@@ -228,7 +228,7 @@ module GPUIterator {
              CPUPercent: int = 0
              )
        where tag == iterKind.leader
-       && isRectangularDom(D)
+       && D.isRectangular()
        && D.dist.type <= Block {
 
       if (debugGPUIterator) {
@@ -255,7 +255,7 @@ module GPUIterator {
              )
       where tag == iterKind.follower
       && followThis.size == 1
-      && isRectangularDom(D)
+      && D.isRectangular()
       && D.dist.type <= Block {
 
       // index-neutral
@@ -279,7 +279,7 @@ module GPUIterator {
              CPUPercent: int = 0
              )
       where tag == iterKind.standalone
-      && isRectangularDom(D)
+      && D.isRectangular()
       && D.dist.type <= Block {
 
       if (debugGPUIterator) {
@@ -305,7 +305,7 @@ module GPUIterator {
              GPUWrapper,
              CPUPercent: int = 0
              )
-      where isRectangularDom(D)
+      where D.isRectangular()
       && D.dist.type <= Block {
 
       if (debugGPUIterator) {


### PR DESCRIPTION
Modules SysCTypes and CPtr have been replaced with CTypes;
common math procedures have moved to (auto-imported) module AutoMath;
size_t is now called c_size_t;
isRectangularDom(D) becomes D.isRectangular().
Updated doc accordingly.