### PR TITLE
fix compile warnings/errors

### DIFF
--- a/src/GPUAPI.h
+++ b/src/GPUAPI.h
@@ -6,9 +6,9 @@ extern "C" {
 void GetDeviceCount(int*);
 void GetDevice(int*);
 void SetDevice(int);
-void ProfilerStart();
-void ProfilerStop();
-void DeviceSynchronize();
+void ProfilerStart(void);
+void ProfilerStop(void);
+void DeviceSynchronize(void);
 void Malloc(void**, size_t);
 void MallocPtr(void***, size_t);
 void MallocPtrPtr(void****, size_t);

--- a/src/GPUIterator.chpl
+++ b/src/GPUIterator.chpl
@@ -229,7 +229,7 @@ module GPUIterator {
              )
        where tag == iterKind.leader
        && D.isRectangular()
-       && D.dist.type <= Block {
+       && isSubtype(D.dist.type, Block) {
 
       if (debugGPUIterator) {
         writeln("[DEBUG GPUITERATOR] GPUIterator (leader, block distributed)");
@@ -256,7 +256,7 @@ module GPUIterator {
       where tag == iterKind.follower
       && followThis.size == 1
       && D.isRectangular()
-      && D.dist.type <= Block {
+      && isSubtype(D.dist.type, Block) {
 
       // index-neutral
       const (followInds,) = followThis;
@@ -280,7 +280,7 @@ module GPUIterator {
              )
       where tag == iterKind.standalone
       && D.isRectangular()
-      && D.dist.type <= Block {
+      && isSubtype(D.dist.type, Block) {
 
       if (debugGPUIterator) {
         writeln("[DEBUG GPUITERATOR] GPUIterator (standalone distributed)");
@@ -306,7 +306,7 @@ module GPUIterator {
              CPUPercent: int = 0
              )
       where D.isRectangular()
-      && D.dist.type <= Block {
+      && isSubtype(D.dist.type, Block) {
 
       if (debugGPUIterator) {
         writeln("[DEBUG GPUITERATOR] GPUIterator (serial distributed)");


### PR DESCRIPTION
This fixes a compile error I see with some C compilers due to invalid function prototypes,
and a warning from the Chapel 1.29 compiler about deprecated type comparison operators.