### PR TITLE
update to Chapel 1.32

### DIFF
--- a/apps/blackscholes/bs.hybrid.dist.chpl
+++ b/apps/blackscholes/bs.hybrid.dist.chpl
@@ -22,7 +22,7 @@ config param verbose = false;
 // For now, these arrays are global so the arrays can be seen from CUDAWrapper
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
-var D: domain(1) dmapped Block(boundingBox = {1..n}) = {1..n};
+var D: domain(1) dmapped blockDist(boundingBox = {1..n}) = {1..n};
 var rand: [D] real(32);
 var put: [D] real(32);
 var call: [D] real(32);

--- a/apps/blackscholes/bs.hybrid.dist.mid.chpl
+++ b/apps/blackscholes/bs.hybrid.dist.mid.chpl
@@ -24,7 +24,7 @@ config param verbose = false;
 // For now, these arrays are global so the arrays can be seen from CUDAWrapper
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
-var D: domain(1) dmapped Block(boundingBox = {1..n}) = {1..n};
+var D: domain(1) dmapped blockDist(boundingBox = {1..n}) = {1..n};
 var rand: [D] real(32);
 var put: [D] real(32);
 var call: [D] real(32);
@@ -32,7 +32,7 @@ var call: [D] real(32);
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchBS(drand: c_void_ptr, dput: c_void_ptr, dcall: c_void_ptr, N: c_size_t);
+extern proc LaunchBS(drand: c_ptr(void), dput: c_ptr(void), dcall: c_ptr(void), N: c_size_t);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)

--- a/apps/blackscholes/bs.hybrid.dist.midlow.chpl
+++ b/apps/blackscholes/bs.hybrid.dist.midlow.chpl
@@ -24,7 +24,7 @@ config param verbose = false;
 // For now, these arrays are global so the arrays can be seen from CUDAWrapper
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
-var D: domain(1) dmapped Block(boundingBox = {1..n}) = {1..n};
+var D: domain(1) dmapped blockDist(boundingBox = {1..n}) = {1..n};
 var rand: [D] real(32);
 var put: [D] real(32);
 var call: [D] real(32);
@@ -32,7 +32,7 @@ var call: [D] real(32);
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchBS(drand: c_void_ptr, dput: c_void_ptr, dcall: c_void_ptr, N: c_size_t);
+extern proc LaunchBS(drand: c_ptr(void), dput: c_ptr(void), dcall: c_ptr(void), N: c_size_t);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)
@@ -44,7 +44,7 @@ proc CUDAWrapper(lo: int, hi: int, N: int) {
   ref lput = put.localSlice(lo .. hi);
   ref lcall = call.localSlice(lo .. hi);
   if (verbose) { ProfilerStart(); }
-  var drand, dput, dcall: c_void_ptr;
+  var drand, dput, dcall: c_ptr(void);
   var size: c_size_t = (lrand.size:c_size_t * c_sizeof(lrand.eltType));
   Malloc(drand, size);
   Malloc(dput, size);

--- a/apps/logisticregression/lr.hybrid.dist.chpl
+++ b/apps/logisticregression/lr.hybrid.dist.chpl
@@ -1,4 +1,5 @@
 use Time;
+use Math;
 use ReplicatedDist;
 ////////////////////////////////////////////////////////////////////////////////
 /// GPUIterator
@@ -25,18 +26,18 @@ config const reduction = false;
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
 const Space1 = {1..nSamples, 1..nFeatures};
-const ReplicatedSpace1 = Space1 dmapped Replicated();
+const ReplicatedSpace1 = Space1 dmapped replicatedDist();
 var X: [ReplicatedSpace1] real(32);
 
 const Space2 = {1..nSamples};
-const ReplicatedSpace2 = Space2 dmapped Replicated();
+const ReplicatedSpace2 = Space2 dmapped replicatedDist();
 var Y: [ReplicatedSpace2] real(32);
 
 const Space3 = {1..nFeatures};
-const ReplicatedSpace3 = Space3 dmapped Replicated();
+const ReplicatedSpace3 = Space3 dmapped replicatedDist();
 var Wcurr: [ReplicatedSpace3] real(32);
 
-var D: domain(1) dmapped Block(boundingBox = {1..nFeatures}) = {1..nFeatures};
+var D: domain(1) dmapped blockDist(boundingBox = {1..nFeatures}) = {1..nFeatures};
 var W: [D] real(32);
 var alpha = 0.1 : real(32);
 

--- a/apps/logisticregression/lr.hybrid.dist.mid.chpl
+++ b/apps/logisticregression/lr.hybrid.dist.mid.chpl
@@ -28,25 +28,25 @@ config const reduction = false;
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
 const Space1 = {1..nSamples, 1..nFeatures};
-const ReplicatedSpace1 = Space1 dmapped Replicated();
+const ReplicatedSpace1 = Space1 dmapped replicatedDist();
 var X: [ReplicatedSpace1] real(32);
 
 const Space2 = {1..nSamples};
-const ReplicatedSpace2 = Space2 dmapped Replicated();
+const ReplicatedSpace2 = Space2 dmapped replicatedDist();
 var Y: [ReplicatedSpace2] real(32);
 
 const Space3 = {1..nFeatures};
-const ReplicatedSpace3 = Space3 dmapped Replicated();
+const ReplicatedSpace3 = Space3 dmapped replicatedDist();
 var Wcurr: [ReplicatedSpace3] real(32);
 
-var D: domain(1) dmapped Block(boundingBox = {1..nFeatures}) = {1..nFeatures};
+var D: domain(1) dmapped blockDist(boundingBox = {1..nFeatures}) = {1..nFeatures};
 var W: [D] real(32);
 var alpha = 0.1 : real(32);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchLR(X: c_void_ptr, Y: c_void_ptr, W: c_void_ptr, Wcurr: c_void_ptr, alpha: real(32), nSamples: int, nFeatures: int, lo: int, hi: int, N: int);
+extern proc LaunchLR(X: c_ptr(void), Y: c_ptr(void), W: c_ptr(void), Wcurr: c_ptr(void), alpha: real(32), nSamples: int, nFeatures: int, lo: int, hi: int, N: int);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)

--- a/apps/mm/mm.hybrid.dist.chpl
+++ b/apps/mm/mm.hybrid.dist.chpl
@@ -23,8 +23,8 @@ config param verbose = false;
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
 const S = {1..n, 1..n};
-const RS = S dmapped Replicated();
-var D: domain(1) dmapped Block(boundingBox = {1..n*n}) = {1..n*n};
+const RS = S dmapped replicatedDist();
+var D: domain(1) dmapped blockDist(boundingBox = {1..n*n}) = {1..n*n};
 
 var A: [D] real(32);
 var B: [RS] real(32);

--- a/apps/mm/mm.hybrid.dist.mid.chpl
+++ b/apps/mm/mm.hybrid.dist.mid.chpl
@@ -25,8 +25,8 @@ config param verbose = false;
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
 const S = {1..n, 1..n};
-const RS = S dmapped Replicated();
-var D: domain(1) dmapped Block(boundingBox = {1..n*n}) = {1..n*n};
+const RS = S dmapped replicatedDist();
+var D: domain(1) dmapped blockDist(boundingBox = {1..n*n}) = {1..n*n};
 
 var A: [D] real(32);
 var B: [RS] real(32);
@@ -35,7 +35,7 @@ var C: [D] real(32);
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchMM(A: c_void_ptr, B: c_void_ptr, C: c_void_ptr, N: int, lo:int, hi:int, GPUN: int, tiled: int);
+extern proc LaunchMM(A: c_ptr(void), B: c_ptr(void), C: c_ptr(void), N: int, lo:int, hi:int, GPUN: int, tiled: int);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)

--- a/apps/mm/mm.hybrid.dist.midlow.chpl
+++ b/apps/mm/mm.hybrid.dist.midlow.chpl
@@ -25,8 +25,8 @@ config param verbose = false;
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
 const S = {1..n, 1..n};
-const RS = S dmapped Replicated();
-var D: domain(1) dmapped Block(boundingBox = {1..n*n}) = {1..n*n};
+const RS = S dmapped replicatedDist();
+var D: domain(1) dmapped blockDist(boundingBox = {1..n*n}) = {1..n*n};
 
 var A: [D] real(32);
 var B: [RS] real(32);
@@ -35,7 +35,7 @@ var C: [D] real(32);
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchMM(A: c_void_ptr, B: c_void_ptr, C: c_void_ptr, N: int, lo:int, hi:int, GPUN: int, tiled: int);
+extern proc LaunchMM(A: c_ptr(void), B: c_ptr(void), C: c_ptr(void), N: int, lo:int, hi:int, GPUN: int, tiled: int);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)
@@ -52,7 +52,7 @@ proc CUDAWrapper(lo: int, hi: int, N: int) {
   assert(lA.size == lC.size);
 
   if (verbose) { ProfilerStart(); }
-  var dA, dB, dC: c_void_ptr;
+  var dA, dB, dC: c_ptr(void);
 
   //writeln("lA.size: ", lA.size, " B.size: ", B.size);
   Malloc(dA, lA.size:c_size_t * c_sizeof(lA.eltType));

--- a/apps/stream/stream.hybrid.dist.chpl
+++ b/apps/stream/stream.hybrid.dist.chpl
@@ -22,7 +22,7 @@ config param verbose = false;
 // For now, these arrays are global so the arrays can be seen from CUDAWrapper
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
-var D: domain(1) dmapped Block(boundingBox = {1..n}) = {1..n};
+var D: domain(1) dmapped blockDist(boundingBox = {1..n}) = {1..n};
 var A: [D] real(32);
 var B: [D] real(32);
 var C: [D] real(32);

--- a/apps/stream/stream.hybrid.dist.mid.chpl
+++ b/apps/stream/stream.hybrid.dist.mid.chpl
@@ -24,7 +24,7 @@ config param verbose = false;
 // For now, these arrays are global so the arrays can be seen from CUDAWrapper
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
-var D: domain(1) dmapped Block(boundingBox = {1..n}) = {1..n};
+var D: domain(1) dmapped blockDist(boundingBox = {1..n}) = {1..n};
 var A: [D] real(32);
 var B: [D] real(32);
 var C: [D] real(32);
@@ -32,7 +32,7 @@ var C: [D] real(32);
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchStream(A: c_void_ptr, B: c_void_ptr, C: c_void_ptr, alpha: c_float, N: c_size_t);
+extern proc LaunchStream(A: c_ptr(void), B: c_ptr(void), C: c_ptr(void), alpha: c_float, N: c_size_t);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)

--- a/apps/stream/stream.hybrid.dist.midlow.chpl
+++ b/apps/stream/stream.hybrid.dist.midlow.chpl
@@ -24,7 +24,7 @@ config param verbose = false;
 // For now, these arrays are global so the arrays can be seen from CUDAWrapper
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
-var D: domain(1) dmapped Block(boundingBox = {1..n}) = {1..n};
+var D: domain(1) dmapped blockDist(boundingBox = {1..n}) = {1..n};
 var A: [D] real(32);
 var B: [D] real(32);
 var C: [D] real(32);
@@ -32,7 +32,7 @@ var C: [D] real(32);
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchStream(A: c_void_ptr, B: c_void_ptr, C: c_void_ptr, alpha: c_float, N: c_size_t);
+extern proc LaunchStream(A: c_ptr(void), B: c_ptr(void), C: c_ptr(void), alpha: c_float, N: c_size_t);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)
@@ -49,7 +49,7 @@ proc CUDAWrapper(lo: int, hi: int, N: int) {
   ref lC = C.localSlice(lo .. hi);
   //writeln("localSlice Size:", lA.size);
   if (verbose) { ProfilerStart(); }
-  var dA, dB, dC: c_void_ptr;
+  var dA, dB, dC: c_ptr(void);
   var size: c_size_t = (lA.size:c_size_t * c_sizeof(lA.eltType));
   Malloc(dA, size);
   Malloc(dB, size);

--- a/apps/vector_copy/vc.hybrid.dist.chpl
+++ b/apps/vector_copy/vc.hybrid.dist.chpl
@@ -21,7 +21,7 @@ config param verbose = false;
 // For now, these arrays are global so the arrays can be seen from CUDAWrapper
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
-var D: domain(1) dmapped Block(boundingBox = {1..n}) = {1..n};
+var D: domain(1) dmapped blockDist(boundingBox = {1..n}) = {1..n};
 var A: [D] real(32);
 var B: [D] real(32);
 

--- a/apps/vector_copy/vc.hybrid.dist.mid.chpl
+++ b/apps/vector_copy/vc.hybrid.dist.mid.chpl
@@ -23,14 +23,14 @@ config param verbose = false;
 // For now, these arrays are global so the arrays can be seen from CUDAWrapper
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
-var D: domain(1) dmapped Block(boundingBox = {1..n}) = {1..n};
+var D: domain(1) dmapped blockDist(boundingBox = {1..n}) = {1..n};
 var A: [D] real(32);
 var B: [D] real(32);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchVC(A: c_void_ptr, B: c_void_ptr, N: c_size_t);
+extern proc LaunchVC(A: c_ptr(void), B: c_ptr(void), N: c_size_t);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)

--- a/apps/vector_copy/vc.hybrid.dist.midlow.chpl
+++ b/apps/vector_copy/vc.hybrid.dist.midlow.chpl
@@ -23,14 +23,14 @@ config param verbose = false;
 // For now, these arrays are global so the arrays can be seen from CUDAWrapper
 // TODO: Explore the possiblity of declaring the arrays and CUDAWrapper
 //       in the main proc (e.g., by using lambdas)
-var D: domain(1) dmapped Block(boundingBox = {1..n}) = {1..n};
+var D: domain(1) dmapped blockDist(boundingBox = {1..n}) = {1..n};
 var A: [D] real(32);
 var B: [D] real(32);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// C Interoperability
 ////////////////////////////////////////////////////////////////////////////////
-extern proc LaunchVC(A: c_void_ptr, B: c_void_ptr, N: c_size_t);
+extern proc LaunchVC(A: c_ptr(void), B: c_ptr(void), N: c_size_t);
 
 // CUDAWrapper is called from GPUIterator
 // to invoke a specific CUDA program (using C interoperability)
@@ -44,7 +44,7 @@ proc CUDAWrapper(lo: int, hi: int, N: int) {
   ref lA = A.localSlice(lo .. hi);
   ref lB = B.localSlice(lo .. hi);
   if (verbose) { ProfilerStart(); }
-  var dA, dB: c_void_ptr;
+  var dA, dB: c_ptr(void);
   var size: c_size_t = (lA.size:c_size_t * c_sizeof(lA.eltType));
   Malloc(dA, size);
   Malloc(dB, size);

--- a/doc/rst/api/gpuapi.rst
+++ b/doc/rst/api/gpuapi.rst
@@ -33,7 +33,7 @@ MID-level API Reference
 
          // Example 2: Distributed array
          use BlockDist;
-         var D: domain(1) dmapped Block(boundingBox = {1..n}) = {1..n};
+         var D: domain(1) dmapped blockDist(boundingBox = {1..n}) = {1..n};
          var A: [D] int;
          proc GPUCallBack(lo: int, hi: int, n: int) {
            // get the local portion of the distributed array
@@ -86,19 +86,19 @@ MID-level API Reference
            dA.free();
          }
 
-   .. method:: dPtr(): c_void_ptr
+   .. method:: dPtr(): c_ptr(void)
 
       Returns a pointer to the allocated device memory.
 
       :returns: pointer to the allocated device memory
-      :rtype: `c_void_ptr`
+      :rtype: `c_ptr(void)`
 
-   .. method:: hPtr(): c_void_ptr
+   .. method:: hPtr(): c_ptr(void)
 
       Returns a pointer to the head of the Chapel array.
 
       :returns: pointer to the head of the Chapel array
-      :rtype: `c_void_ptr`
+      :rtype: `c_ptr(void)`
 
 
 .. method:: toDevice(args: GPUArray ...?n)
@@ -136,7 +136,7 @@ MID-level API Reference
 MID-LOW-level API Reference
 ############################
 
-.. method:: Malloc(ref devPtr: c_void_ptr, size: c_size_t)
+.. method:: Malloc(ref devPtr: c_ptr(void), size: c_size_t)
 
    Allocates memory on the device.
 
@@ -153,7 +153,7 @@ MID-LOW-level API Reference
       var A: [1..n] int;
 
       proc GPUCallBack(lo: int, hi: int, N: int) {
-        var dA: c_void_ptr;
+        var dA: c_ptr(void);
         Malloc(dA, (A.size: c_size_t) * c_sizeof(A.eltType));
         ...
       }
@@ -163,10 +163,10 @@ MID-LOW-level API Reference
 
       // Example 2: Distributed array
       use BlockDist;
-      var D: domain(1) dmapped Block(boundingBox = {1..n}) = {1..n};
+      var D: domain(1) dmapped blockDist(boundingBox = {1..n}) = {1..n};
       var A: [D] int;
       proc GPUCallBack(lo: int, hi: int, n: int) {
-        var dA: c_void_ptr;
+        var dA: c_ptr(void);
         // get the local portion of the distributed array
         var localA = A.localSlice(lo...hi);
         Malloc(dA, (localA.size: c_size_t) * c_sizeof(localA.eltType));
@@ -180,7 +180,7 @@ MID-LOW-level API Reference
 
 
 
-.. method:: MallocPitch(ref devPtr: c_void_ptr, ref pitch: c_size_t, width: c_size_t, height: c_size_t)
+.. method:: MallocPitch(ref devPtr: c_ptr(void), ref pitch: c_size_t, width: c_size_t, height: c_size_t)
 
    Allocates pitched 2D memory on the device.
 
@@ -198,15 +198,15 @@ MID-LOW-level API Reference
 
    .. note:: A working example can be found `here <https://github.com/ahayashi/chapel-gpu/blob/master/example/gpuapi/pitched2d/pitched2d.chpl>`_. The detailed descirption of the underlying CUDA API can be found `here <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html#group__CUDART__MEMORY_1g32bd7a39135594788a542ae72217775c>`_.
 
-.. method:: Memcpy(dst: c_void_ptr, src: c_void_ptr, count: c_size_t, kind: int)
+.. method:: Memcpy(dst: c_ptr(void), src: c_ptr(void), count: c_size_t, kind: int)
 
    Transfers data between the host and the device
 
    :arg dst: the desination address
-   :type dst: `c_void_ptr`
+   :type dst: `c_ptr(void)`
 
    :arg src: the source address
-   :type src: `c_void_ptr`
+   :type src: `c_ptr(void)`
 
    :arg count: size in bytes to be transferred
    :type count: `c_size_t`
@@ -221,7 +221,7 @@ MID-LOW-level API Reference
       var A: [1..n] int;
 
       proc GPUCallBack(lo: int, hi: int, N: int) {
-        var dA: c_void_ptr;
+        var dA: c_ptr(void);
         Malloc(dA, (A.size: c_size_t) * c_sizeof(A.eltType));
         // host-to-device
         Memcpy(dA, c_ptrTo(A), size, 0);
@@ -231,18 +231,18 @@ MID-LOW-level API Reference
 
    .. note:: ``c_ptrTo(A)`` returns a pointer to the Chapel rectangular array ``A``. For more details, see `this document <https://chapel-lang.org/docs/builtins/CPtr.html#CPtr.c_ptrTo>`_.
 
-.. method:: Memcpy2D(dst: c_void_ptr, dpitch: c_size_t, src: c_void_ptr, spitch: c_size_t, width: c_size_t, height:c_size_t, kind: int)
+.. method:: Memcpy2D(dst: c_ptr(void), dpitch: c_size_t, src: c_ptr(void), spitch: c_size_t, width: c_size_t, height:c_size_t, kind: int)
 
    Transfers pitched 2D array between the host and the device
 
    :arg dst: the desination address
-   :type dst: `c_void_ptr`
+   :type dst: `c_ptr(void)`
 
    :arg dpitch: the pitch of destination memory
    :type dpitch: `c_size_t`
 
    :arg src: the source address
-   :type src: `c_void_ptr`
+   :type src: `c_ptr(void)`
 
    :arg spitch: the pitch of source memory
    :type spitch: `c_size_t`
@@ -258,12 +258,12 @@ MID-LOW-level API Reference
 
    .. note:: A working example can be found `here <https://github.com/ahayashi/chapel-gpu/blob/master/example/gpuapi/pitched2d/pitched2d.chpl>`_. The detailed descirption of the underlying CUDA API can be found `here <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html#group__CUDART__MEMORY_1g3a58270f6775efe56c65ac47843e7cee>`_.
 
-.. method:: Free(devPtr: c_void_ptr)
+.. method:: Free(devPtr: c_ptr(void))
 
    Frees memory on the device
 
    :arg devPtr: Device pointer to memory to be freed.
-   :type devPtr: `c_void_ptr`
+   :type devPtr: `c_ptr(void)`
 
 .. method:: GetDeviceCount(ref count: int(32))
 

--- a/doc/rst/details/gpuapi.rst
+++ b/doc/rst/details/gpuapi.rst
@@ -15,7 +15,7 @@ The GPUAPI module provides Chapel-level GPU API. The use of the API assumes case
 
 * `MID-LOW-level`: Provides wrapper functions for raw GPU API functions
 
-  * Example: ``var ga: c_void_ptr = Malloc(sizeInBytes);``
+  * Example: ``var ga: c_ptr(void) = Malloc(sizeInBytes);``
 
 
 

--- a/doc/rst/index.rst
+++ b/doc/rst/index.rst
@@ -18,7 +18,7 @@ This document describes the following two Chapel modules that facilitate GPU pro
 
     * `MID-LOW-level`: Provides wrapper functions for raw GPU API functions
 
-       * Example: :chapel:`var ga: c_void_ptr = Malloc(sizeInBytes);`
+       * Example: :chapel:`var ga: c_ptr(void) = Malloc(sizeInBytes);`
 
 
 Also, in this document, for categorization purposes, the term `LOW-level` is referred to a GPUIterator only version, where the GPUIterator is only used for invoking raw GPU programs in which there is no Chapel-level abstraction.

--- a/doc/rst/instructions/build.rst
+++ b/doc/rst/instructions/build.rst
@@ -5,7 +5,7 @@ Building Chapel-GPU
 Prerequisites
 ##############
 
-* Chapel: 1.28. Detailed instructions for installing Chapel can be found: `here <https://chapel-lang.org/docs/usingchapel/QUICKSTART.html>`_.
+* Chapel: 1.32. Detailed instructions for installing Chapel can be found: `here <https://chapel-lang.org/docs/usingchapel/QUICKSTART.html>`_.
 
 * GPU Compilers & Runtimes: ``GPUIterator`` and ``GPUAPI`` require either of the following GPU programing environments.
 

--- a/doc/rst/instructions/low.rst
+++ b/doc/rst/instructions/low.rst
@@ -239,7 +239,7 @@ In the multi-locale scenario, you are supposed to update ``vc.hybrid.chpl`` slig
       :emphasize-lines: 2-4
 
       config const n = 32: int;
-      var D: domain(1) dmapped Block(boundingBox = {1..n}) = {1..n};
+      var D: domain(1) dmapped blockDist(boundingBox = {1..n}) = {1..n};
       var A: [D] real(32);
       var B: [D] real(32);
       // var A: [1..n] real(32); /* single locale version */

--- a/doc/rst/instructions/mid-low.rst
+++ b/doc/rst/instructions/mid-low.rst
@@ -34,13 +34,13 @@ The biggest motivation for introducing ``MID-LOW`` and ``MID`` -level GPU API is
      }
    }
 
-At the MID-LOW-level, most of the CUDA/HIP/OpenCL-level 1) device memory allocation, 2) device synchronization, and 3) data transfer can be written in Chapel. However, it's worth noting that this level of abstraction only provides thin wrapper functions for the CUDA/HIP/OpenCL-level API functions, which requires you to directly manipulate C types like ``c_void_ptr`` and so on. The MID-LOW is helpful particularly when you want to fine-tune the use of GPU API, but still want to stick with Chapel. Here is an example program written with the MID-LOW-level API:
+At the MID-LOW-level, most of the CUDA/HIP/OpenCL-level 1) device memory allocation, 2) device synchronization, and 3) data transfer can be written in Chapel. However, it's worth noting that this level of abstraction only provides thin wrapper functions for the CUDA/HIP/OpenCL-level API functions, which requires you to directly manipulate C types like ``c_ptr(void)`` and so on. The MID-LOW is helpful particularly when you want to fine-tune the use of GPU API, but still want to stick with Chapel. Here is an example program written with the MID-LOW-level API:
 
 .. code-block:: chapel
    :caption: vc.hybrid.chpl
 
    proc GPUCallBack(lo: int, hi: int, N: int) {
-     var dA, dB: c_void_ptr;
+     var dA, dB: c_ptr(void);
      var size: c_size_t = (lA.size:c_size_t * c_sizeof(lA.eltType));
      Malloc(dA, size);
      Malloc(dB, size);

--- a/example/gpuapi/1d/1d.chpl
+++ b/example/gpuapi/1d/1d.chpl
@@ -1,14 +1,14 @@
 use GPUAPI;
 use CTypes;
 
-extern proc kernel(dA: c_void_ptr, n: int);
+extern proc kernel(dA: c_ptr(void), n: int);
 
 var D = {0..31};
 var A: [D] int;
 var V: [D] int; // for verification
 
 // initialization proc
-proc init() {
+proc initialize() {
     for i in D {
         A[i] = i;
     }
@@ -17,9 +17,9 @@ proc init() {
 
 // MID-LOW
 // dA is a linearized 1D GPU array
-init();
+initialize();
 
-var dA: c_void_ptr;
+var dA: c_ptr(void);
 var size: c_size_t = A.size:c_size_t * c_sizeof(A.eltType);
 Malloc(dA, size);
 Memcpy(dA, c_ptrTo(A), size, 0);
@@ -35,7 +35,7 @@ if (A.equals(V)) {
 }
 
 // MID
-init();
+initialize();
 
 var dA2 = new GPUArray(A);
 dA2.toDevice();

--- a/example/gpuapi/2d/2d.chpl
+++ b/example/gpuapi/2d/2d.chpl
@@ -1,14 +1,14 @@
 use GPUAPI;
 use CTypes;
 
-extern proc kernel(dA: c_void_ptr, nRows: int, nCols: int);
+extern proc kernel(dA: c_ptr(void), nRows: int, nCols: int);
 
 var D = {0..8, 0..8};
 var A: [D] int;
 var V: [D] int; // for verification
 
 // initialization proc
-proc init() {
+proc initialize() {
     for (i, j) in D {
         A[i, j] = (i+1)*10 + j;
     }
@@ -17,9 +17,9 @@ proc init() {
 
 // MID-LOW
 // dA is a linearized 1D GPU array
-init();
+initialize();
 
-var dA: c_void_ptr;
+var dA: c_ptr(void);
 var size: c_size_t = A.size:c_size_t * c_sizeof(A.eltType);
 Malloc(dA, size);
 Memcpy(dA, c_ptrTo(A), size, 0);
@@ -35,7 +35,7 @@ if (A.equals(V)) {
 }
 
 // MID
-init();
+initialize();
 
 var dA2 = new GPUArray(A);
 dA2.toDevice();

--- a/example/gpuapi/async/async.chpl
+++ b/example/gpuapi/async/async.chpl
@@ -2,7 +2,7 @@ use GPUAPI;
 use CTypes;
 use Futures;
 
-extern proc kernel(dA: c_void_ptr);
+extern proc kernel(dA: c_ptr(void));
 
 var D = {0..127};
 var A: [D] int;

--- a/example/gpuapi/pitched2d/pitched2d.chpl
+++ b/example/gpuapi/pitched2d/pitched2d.chpl
@@ -1,14 +1,14 @@
 use GPUAPI;
 use CTypes;
 
-extern proc kernel(dA: c_void_ptr, nRows: c_size_t, nCols: c_size_t, dpitch: c_size_t);
+extern proc kernel(dA: c_ptr(void), nRows: c_size_t, nCols: c_size_t, dpitch: c_size_t);
 
 var D = {0..8, 0..8};
 var A: [D] int;
 var V: [D] int; // for verification
 
 // initialization proc
-proc init() {
+proc initialize() {
     for (i, j) in D {
         A[i, j] = (i+1)*10 + j;
     }
@@ -16,9 +16,9 @@ proc init() {
 }
 
 // MID-LOW
-init();
+initialize();
 
-var dA: c_void_ptr;
+var dA: c_ptr(void);
 var hpitch: c_size_t = D.dim(1).size:c_size_t * c_sizeof(A.eltType);
 var dpitch: c_size_t;
 
@@ -39,7 +39,7 @@ if (A.equals(V)) {
 }
 
 // MID (not pitched)
-init();
+initialize();
 var dA2 = new GPUArray(A);
 writeln("MID (pitch=false) pitch on the host:", dA2.hpitch);
 writeln("MID (pitch=false) pitch on the device: ", dA2.dpitch);
@@ -61,7 +61,7 @@ if (A.equals(V)) {
 }
 
 // MID (pitched)
-init();
+initialize();
 var dA3 = new GPUArray(A, true);
 writeln("MID (pitch=true) pitch on the host:", dA3.hpitch);
 writeln("MID (pitch=true) pitch on the device: ", dA3.dpitch);

--- a/src/GPUIterator.chpl
+++ b/src/GPUIterator.chpl
@@ -256,7 +256,7 @@ module GPUIterator {
       where tag == iterKind.follower
       && followThis.size == 1
       && D.isRectangular()
-      && isSubtype(D.dist.type, blockDist) {
+      && isSubtype(D.distribution.type, blockDist) {
 
       // index-neutral
       const (followInds,) = followThis;

--- a/src/GPUIterator.chpl
+++ b/src/GPUIterator.chpl
@@ -223,13 +223,13 @@ module GPUIterator {
 
     // leader (block distributed domains)
     iter GPU(param tag: iterKind,
-             D: domain,
+             D: domain(?),
              GPUWrapper,
              CPUPercent: int = 0
              )
        where tag == iterKind.leader
        && D.isRectangular()
-       && isSubtype(D.dist.type, Block) {
+       && isSubtype(D.distribution.type, blockDist) {
 
       if (debugGPUIterator) {
         writeln("[DEBUG GPUITERATOR] GPUIterator (leader, block distributed)");
@@ -248,7 +248,7 @@ module GPUIterator {
 
     // follower (block distributed domains)
     iter GPU(param tag: iterKind,
-             D: domain,
+             D: domain(?),
              GPUWrapper,
              CPUPercent: int = 0,
              followThis
@@ -256,7 +256,7 @@ module GPUIterator {
       where tag == iterKind.follower
       && followThis.size == 1
       && D.isRectangular()
-      && isSubtype(D.dist.type, Block) {
+      && isSubtype(D.dist.type, blockDist) {
 
       // index-neutral
       const (followInds,) = followThis;
@@ -274,13 +274,13 @@ module GPUIterator {
 
     // standalone (block distributed domains)
     iter GPU(param tag: iterKind,
-             D: domain,
+             D: domain(?),
              GPUWrapper,
              CPUPercent: int = 0
              )
       where tag == iterKind.standalone
       && D.isRectangular()
-      && isSubtype(D.dist.type, Block) {
+      && isSubtype(D.distribution.type, blockDist) {
 
       if (debugGPUIterator) {
         writeln("[DEBUG GPUITERATOR] GPUIterator (standalone distributed)");
@@ -301,12 +301,12 @@ module GPUIterator {
     }
 
     // serial iterator (block distributed domains)
-    iter GPU(D: domain,
+    iter GPU(D: domain(?),
              GPUWrapper,
              CPUPercent: int = 0
              )
       where D.isRectangular()
-      && isSubtype(D.dist.type, Block) {
+      && isSubtype(D.distribution.type, blockDist) {
 
       if (debugGPUIterator) {
         writeln("[DEBUG GPUITERATOR] GPUIterator (serial distributed)");


### PR DESCRIPTION
This pull request fixes warnings in GPUAPI and example code due to deprecations in Chapel 1.32.

Block -> blockDist
Replicated -> replicatedDist
generic domain -> domain(?)
c_void_ptr -> c_ptr(void)
this.complete() -> init this
domain.dist -> domain.distribution